### PR TITLE
Corrected PRESSTENS calculation in imd_forces_meam.c

### DIFF
--- a/src/imd_forces_meam.c
+++ b/src/imd_forces_meam.c
@@ -563,16 +563,11 @@ void do_forces2(cell *p, real *Epot, real *Virial,
 	      KRAFT(p,i,Z) -= force_k.z;
 
 #ifdef P_AXIAL
-/*        tmp_vir_vect.x += d[k].x * force_k.x;
-        tmp_vir_vect.y += d[k].y * force_k.y;
-        tmp_vir_vect.z += d[k].z * force_k.z;
-*/
         tmp_vir_vect.x += d[k].x * force_k.x;
         tmp_vir_vect.y += d[k].y * force_k.y;
         tmp_vir_vect.z += d[k].z * force_k.z;
 
 #else
-/*        tmp_virial     += SPROD(d[k],force_k); */
         tmp_virial     += SPROD(d[k],force_k);
 #endif
 


### PR DESCRIPTION
Forces and pressures were somehow antiparallel in imd_forces_meam.c leading to correct absolute values but inversed pressure values, e.g. compression instead of tension, which might especially gain importance if one tries to use homdef with pressure relaxation. I.e. then the box size was further increased even though the configuration already faced tensile stresses...
