### PR TITLE
Bugfix for VISCOUS

### DIFF
--- a/src/imd_io.c
+++ b/src/imd_io.c
@@ -3517,7 +3517,7 @@ void broadcast_header(header_info_t *info)
 #ifdef VARCHG
   MPI_Bcast( &(info->n_charge),   1, MPI_INT,  0, MPI_COMM_WORLD); 
 #endif
-#ifdef VARCHG
+#ifdef VISCOUS
   MPI_Bcast( &(info->n_friction),   1, MPI_INT,  0, MPI_COMM_WORLD);
 #endif
 }


### PR DESCRIPTION
Feature VISCOUS was not working in the combination of 1. MPI, 2.
parallel input and 3. friction coefficient defined per particle.

Reason: Forgot to modify condition after copy&paste