### PR TITLE
Provided upwards compatibility for IMD with MPI3

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -237,7 +237,7 @@
 *
 ******************************************************************************/
 
-#if defined(MPI) && (MPI_VERSION==2)
+#if defined(MPI) && (MPI_VERSION>=2)
 #define MPI2
 #endif
 

--- a/src/imd_loadBalance_direct.c
+++ b/src/imd_loadBalance_direct.c
@@ -206,7 +206,7 @@ int lb_syncBufferCellAffinity() {
 	MPI_Alloc_mem(8*3*num_cpus * sizeof *allCorners, MPI_INFO_NULL, &allCorners);
 #else
 	corners = malloc(8*3*sizeof *corners);
-	allCallCorners = malloc(8*3*num_cpus * sizeof *allCorners);
+	allCorners = malloc(8*3*num_cpus * sizeof *allCorners);
 #endif
 
 	for (i = 0; i<8; i++){


### PR DESCRIPTION
Due to a hardcoded check for equality, IMD was falling back to the MPI1 implementation on machines with MPI libraries supporting MPI3.
Fixed a typo that caused a compiler error in the loadbalancer that helped to identify this problem as well.
